### PR TITLE
Transcript in output

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ ruby_version_file = File.expand_path('.ruby-version', __dir__)
 ruby_version_exact = File.read(ruby_version_file).strip
 ruby ruby_version_exact
 
-gem 'berkeley_library-av-core', '~> 0.4.1'
+gem 'berkeley_library-av-core', '~> 0.4.2'
 gem 'berkeley_library-docker', '~> 0.2.0'
 gem 'berkeley_library-logging', '~> 0.2'
 gem 'browser', '~> 4.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,7 +70,7 @@ GEM
       public_suffix (>= 2.0.2, < 6.0)
     amazing_print (1.5.0)
     ast (2.4.2)
-    berkeley_library-av-core (0.4.1)
+    berkeley_library-av-core (0.4.2)
       berkeley_library-logging (~> 0.2)
       berkeley_library-marc (~> 0.2, >= 0.2.1)
       berkeley_library-util (~> 0.1, >= 0.1.1)
@@ -357,7 +357,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  berkeley_library-av-core (~> 0.4.1)
+  berkeley_library-av-core (~> 0.4.2)
   berkeley_library-docker (~> 0.2.0)
   berkeley_library-logging (~> 0.2)
   brakeman

--- a/app/views/player/_record.html.erb
+++ b/app/views/player/_record.html.erb
@@ -5,6 +5,7 @@
 <section class="record">
 
   <h1><%= record.title %></h1>
+  
   <% if record.tracks.empty? %>
     <p>No track information found.</p>
   <% else %>

--- a/app/views/player/_record.html.erb
+++ b/app/views/player/_record.html.erb
@@ -5,7 +5,22 @@
 <section class="record">
 
   <h1><%= record.title %></h1>
-
+  <% #record.metadata.marc_record.class %>
+  <% transcripts = [] %>
+  <% eight56_fields = record.metadata.marc_record.fields(['856']) %>
+  <% if eight56_fields.any? %>
+    <% #eight56_fields.each {|f| f.to_hash } %>
+    <% eight56_fields.each do |f| %>
+      <% if f.indicator1 == '4' && f.indicator2 == '2' %>
+        <% subfields = f.subfields.each_with_object({}) {|sf, hash| hash[sf.code] = sf.value } %>
+        <% if subfields['u'] && subfields['y'] && subfields['y'].downcase.include?('transcript') %>
+          <% transcripts << subfields['u']  %>
+        <% end %>
+      <% end %>
+            
+    <% end %>
+  <% end %>
+  <% #byebug %>
   <% if record.tracks.empty? %>
     <p>No track information found.</p>
   <% else %>
@@ -85,6 +100,14 @@
             <% end %>
           </td>
         </tr>
+      <% end %>
+      <% if transcripts.any? %>
+        <tr>
+          <th><p>Transcripts</p></th>
+          <td>
+            <% transcripts.each do |transcript| %>
+              <%= link_to(File.basename(URI.parse(transcript).path), transcript) %>
+            <% end %>
       <% end %>
     <% end %>
     </tbody>

--- a/app/views/player/_record.html.erb
+++ b/app/views/player/_record.html.erb
@@ -85,31 +85,6 @@
           </td>
         </tr>
       <% end %>
-
-      <% transcripts = [] %>
-      <% eight56_fields = record.metadata.marc_record.fields(['856']) %>
-      <% if eight56_fields.any? %>
-        <% #eight56_fields.each {|f| f.to_hash } %>
-        <% eight56_fields.each do |f| %>
-          <% if f.indicator1 == '4' && f.indicator2 == '2' %>
-            <% subfields = f.subfields.each_with_object({}) {|sf, hash| hash[sf.code] = sf.value } %>
-            <% if subfields['u'] && subfields['y'] && subfields['y'].downcase.include?('transcript') %>
-              <% transcripts << subfields  %>
-            <% end %>
-          <% end %>
-                
-        <% end %>
-      <% end %>
-      <% if transcripts.any? %>
-        <tr>
-          <th><p>Transcripts</p></th>
-          <td>
-            <% transcripts.each do |transcript| %>
-              <%= link_to(transcript['y'], transcript['u']) %>
-            <% end %>
-          </td>
-        </tr>
-      <% end %>
     <% end %>
     </tbody>
   </table>

--- a/app/views/player/_record.html.erb
+++ b/app/views/player/_record.html.erb
@@ -5,7 +5,7 @@
 <section class="record">
 
   <h1><%= record.title %></h1>
-  
+
   <% if record.tracks.empty? %>
     <p>No track information found.</p>
   <% else %>

--- a/app/views/player/_record.html.erb
+++ b/app/views/player/_record.html.erb
@@ -5,22 +5,6 @@
 <section class="record">
 
   <h1><%= record.title %></h1>
-  <% #record.metadata.marc_record.class %>
-  <% transcripts = [] %>
-  <% eight56_fields = record.metadata.marc_record.fields(['856']) %>
-  <% if eight56_fields.any? %>
-    <% #eight56_fields.each {|f| f.to_hash } %>
-    <% eight56_fields.each do |f| %>
-      <% if f.indicator1 == '4' && f.indicator2 == '2' %>
-        <% subfields = f.subfields.each_with_object({}) {|sf, hash| hash[sf.code] = sf.value } %>
-        <% if subfields['u'] && subfields['y'] && subfields['y'].downcase.include?('transcript') %>
-          <% transcripts << subfields['u']  %>
-        <% end %>
-      <% end %>
-            
-    <% end %>
-  <% end %>
-  <% #byebug %>
   <% if record.tracks.empty? %>
     <p>No track information found.</p>
   <% else %>
@@ -101,13 +85,30 @@
           </td>
         </tr>
       <% end %>
+
+      <% transcripts = [] %>
+      <% eight56_fields = record.metadata.marc_record.fields(['856']) %>
+      <% if eight56_fields.any? %>
+        <% #eight56_fields.each {|f| f.to_hash } %>
+        <% eight56_fields.each do |f| %>
+          <% if f.indicator1 == '4' && f.indicator2 == '2' %>
+            <% subfields = f.subfields.each_with_object({}) {|sf, hash| hash[sf.code] = sf.value } %>
+            <% if subfields['u'] && subfields['y'] && subfields['y'].downcase.include?('transcript') %>
+              <% transcripts << subfields  %>
+            <% end %>
+          <% end %>
+                
+        <% end %>
+      <% end %>
       <% if transcripts.any? %>
         <tr>
           <th><p>Transcripts</p></th>
           <td>
             <% transcripts.each do |transcript| %>
-              <%= link_to(File.basename(URI.parse(transcript).path), transcript) %>
+              <%= link_to(transcript['y'], transcript['u']) %>
             <% end %>
+          </td>
+        </tr>
       <% end %>
     <% end %>
     </tbody>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   app:
     build: .
@@ -15,3 +13,5 @@ services:
       # Note that this mounts the *entire* repo directory (including
       # files ignored in .dockerignore when building the image)
       - ./:/opt/app
+    tty: true
+    stdin_open: true


### PR DESCRIPTION
see AP-271. 

If the string "transcript" shows up in an 856 42$y value, then we use that value as the link text and the corresponding $u for the url value.  If there are multiple transcripts, it will place a link for each one.  Note: if there actually are more than one transcript for a given record, it would be a good practice to disambiguate them in their $y link descriptions. 